### PR TITLE
Bug 742137 - Run ISPDB on Django 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ for the Thunderbird autoconfig database
 1. python ../manage.py syncdb
 2. convert existing XML data to the DB:
 
-   # have http://svn.mozilla.org/mozillamessaging.com/sites/autoconfig.mozillamessaging.com/trunk checked out at ../autoconfig_data
-
-   # if autoconfig_data is somewhere else, you can set the env't var AUTOCONFIG_DATA to  point to it
-
+   have http://svn.mozilla.org/mozillamessaging.com/sites/autoconfig.mozillamessaging.com/trunk checked out at ../autoconfig_data
+   
+   if autoconfig_data is somewhere else, you can set the env't var AUTOCONFIG_DATA to  point to it
+   
    echo 'import ispdb.convert;ispdb.convert.main()' | python ../manage.py shell
 
 3. python ../manage.py runserver


### PR DESCRIPTION
Bug 742137 - Run ISPDB on Django 1.4

```
List of changes:
- Moved static files (css, .js, images, etc.) to config/static (NEW DJANGO LAYOUT)
- Moved manage.py to one top-level dir (NEW DJANGO LAYOUT)
- Removed local_settings. Using settings.py for development now.
- Changes in settings.py to work with Django 1.4
- Changed templates to use STATIC_URL instead of MEDIA_URL
- Changes apache/production.py, apache/ispdb.wsgi and apache/wsgi.conf to use recommended WSGI functions of Django 1.4
- Added csrf_token to post forms
- Changes in urls.py to use new staticserve methods
```
