### PR TITLE
588136: Make ispdb cache-friendly

### DIFF
--- a/ispdb/fixtures/xml_testdata.json
+++ b/ispdb/fixtures/xml_testdata.json
@@ -8,6 +8,14 @@
         }
     },
     {
+        "pk":2,
+        "model":"config.domain",
+        "fields": {
+            "config": 2,
+            "name": "test2.com"
+        }
+    },
+    {
         "pk":1,
         "model":"config.config",
         "fields": {
@@ -24,9 +32,37 @@
             "incoming_hostname":"hostname_in",
             "outgoing_username_form":"%EMAILLOCALPART%",
             "display_short_name":"netzero",
-            "status":"requested",
+            "status":"approved",
             "incoming_port":143,
             "last_update_datetime": "2012-05-31T21:08:11.305Z",
+            "incoming_username_form":"",
+            "outgoing_hostname":"hostname_out",
+            "incoming_type":"imap",
+            "locked": "False"
+        }
+    },
+    {
+        "pk":2,
+        "model":"config.config",
+        "fields": {
+            "outgoing_use_global_preferred_server":false,
+            "incoming_socket_type":"SSL",
+            "outgoing_port":25,
+            "flagged_by_email":"",
+            "flagged_as_incorrect":false,
+            "email_provider_id":"test.com",
+            "incoming_authentication":"password-cleartext",
+            "display_name":"NetZero Email",
+            "outgoing_add_this_server":false,
+            "outgoing_socket_type":"SSL",
+            "created_datetime": "2012-05-31T21:08:09.314Z",
+            "outgoing_authentication":"password-cleartext",
+            "incoming_hostname":"hostname_in",
+            "outgoing_username_form":"%EMAILLOCALPART%",
+            "display_short_name":"netzero",
+            "status":"approved",
+            "incoming_port":143,
+            "last_update_datetime": "2012-04-30T21:08:11.305Z",
             "incoming_username_form":"",
             "outgoing_hostname":"hostname_out",
             "incoming_type":"imap",

--- a/ispdb/settings.py
+++ b/ispdb/settings.py
@@ -100,6 +100,7 @@ TEMPLATE_LOADERS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -107,6 +108,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
 ROOT_URLCONF = 'ispdb.urls'
@@ -155,3 +157,9 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "django.core.context_processors.request",
     "django_browserid.context_processors.browserid_form",
 )
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}

--- a/ispdb/tests/test_cache.py
+++ b/ispdb/tests/test_cache.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+from nose.tools import assert_true
+
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.utils.timezone import utc
+
+from ispdb.config.models import Config
+
+
+class CacheTest(TestCase):
+
+    fixtures = ['login_testdata', 'xml_testdata']
+
+    def test_default_cache(self):
+        res = self.client.get(reverse("ispdb_list"))
+        assert_true('Cache-Control' in res)
+        assert_true(res['Cache-Control'] == 'max-age=600')
+
+    def test_list_xml_cache(self):
+        res = self.client.get(reverse("ispdb_list", args=['xml']))
+        assert_true('Cache-Control' in res)
+        assert_true(res['Cache-Control'] == 'no-cache, max-age=600')
+        config = Config.objects.get(pk=1)
+        assert_true('Last-Modified' in res)
+        d = datetime.strptime(res['Last-Modified'], "%a, %d %b %Y %H:%M:%S "
+            "%Z").replace(tzinfo=utc)
+        c = config.last_update_datetime.replace(microsecond=0)
+        assert_true(d == c)
+
+    def test_export_xml_cache(self):
+        res = self.client.get(reverse("ispdb_export_xml", args=[2]))
+        assert_true('Cache-Control' in res)
+        assert_true(res['Cache-Control'] == 'no-cache, max-age=600')
+        config = Config.objects.get(pk=2)
+        assert_true('Last-Modified' in res)
+        d = datetime.strptime(res['Last-Modified'], "%a, %d %b %Y %H:%M:%S "
+            "%Z").replace(tzinfo=utc)
+        c = config.last_update_datetime.replace(microsecond=0)
+        assert_true(d == c)


### PR DESCRIPTION
- add a default max-age of 600s.
- for export_xml/id (exports a config XML): set no-cache to Cache-Control (it will cache but will always check with the server if the cache file is updated, and we can provide the last-update value using config.last_update_datetime)
- list/xml/ (export list with config IDs and its last_update_datetime) - set no-cache to Cache-Control and use last-update as the most recent config.last_update_datetime
